### PR TITLE
Capture email address with its local part being scheme string

### DIFF
--- a/packages/linkifyjs/src/parser.js
+++ b/packages/linkifyjs/src/parser.js
@@ -115,6 +115,10 @@ export function init({ groups }) {
 
 	tt(Localpart, tk.AT, LocalpartAt); // close to an email address now
 
+	// Local part of an email address can be e.g. 'http' or 'mailto'
+	tt(Scheme, tk.AT, LocalpartAt);
+	tt(SlashScheme, tk.AT, LocalpartAt);
+
 	const LocalpartDot = tt(Localpart, tk.DOT); // Local part of the email address plus '.' (localpart cannot end in .)
 	ta(LocalpartDot, localpartAccepting, Localpart);
 	ta(LocalpartDot, groups.domain, Localpart);

--- a/test/spec/linkifyjs/parser.test.js
+++ b/test/spec/linkifyjs/parser.test.js
@@ -233,6 +233,14 @@ const tests = [
 		[Email],
 		['~emersion/soju-dev@lists.sr.ht']
 	], [
+		'http@example.com',
+		[Email],
+		['http@example.com']
+	], [
+		'mailto@example.com',
+		[Email],
+		['mailto@example.com']
+	], [
 		'http.org',
 		[Url],
 		['http.org']


### PR DESCRIPTION
This patch fixes the parser so that it can capture an email address whose local part matches a scheme string, e.g. 'http' or 'mailto'.

Fixes https://github.com/Hypercontext/linkifyjs/issues/414