### PR TITLE
FIx jsdoc in linkify-react

### DIFF
--- a/packages/linkify-react/src/linkify-react.js
+++ b/packages/linkify-react/src/linkify-react.js
@@ -83,7 +83,7 @@ function linkifyReactElement(element, opts, meta) {
 /**
  * @template P
  * @template {string | React.JSXElementConstructor<P>} T
- * @param {P & { as?: T, tagName?: T, tagName?: T, options?: import('linkifyjs').Opts, children?: React.ReactNode}} props
+ * @param {P & { as?: T, tagName?: T, options?: import('linkifyjs').Opts, children?: React.ReactNode}} props
  * @returns {React.ReactElement<P, T>}
  */
 const Linkify = (props) => {


### PR DESCRIPTION
Just removed duplicate `tagName?` param.