### PR TITLE
Fix hashtag plugin: add support for full width middle dot `・`

### DIFF
--- a/packages/linkify-plugin-hashtag/src/hashtag.js
+++ b/packages/linkify-plugin-hashtag/src/hashtag.js
@@ -6,9 +6,9 @@ const HashtagToken = createTokenClass('hashtag', { isLink: true });
 /**
  * @type {import('linkifyjs').Plugin}
  */
- export default function hashtag({ scanner, parser }) {
+export default function hashtag({ scanner, parser }) {
 	// Various tokens that may compose a hashtag
-	const { POUND, UNDERSCORE } = scanner.tokens;
+	const { POUND, UNDERSCORE, FULLWIDTHMIDDLEDOT } = scanner.tokens;
 	const { alpha, numeric, alphanumeric, emoji } = scanner.tokens.groups;
 
 	// Take or create a transition from start to the '#' sign (non-accepting)
@@ -21,11 +21,14 @@ const HashtagToken = createTokenClass('hashtag', { isLink: true });
 	Hash.ta(numeric, HashPrefix);
 	Hash.ta(alpha, Hashtag);
 	Hash.ta(emoji, Hashtag);
+	Hash.ta(FULLWIDTHMIDDLEDOT, Hashtag);
 	HashPrefix.ta(alpha, Hashtag);
 	HashPrefix.ta(emoji, Hashtag);
+	HashPrefix.ta(FULLWIDTHMIDDLEDOT, Hashtag);
 	HashPrefix.ta(numeric, HashPrefix);
 	HashPrefix.tt(UNDERSCORE, HashPrefix);
 	Hashtag.ta(alphanumeric, Hashtag);
 	Hashtag.ta(emoji, Hashtag);
+	Hashtag.tt(FULLWIDTHMIDDLEDOT, Hashtag);
 	Hashtag.tt(UNDERSCORE, Hashtag); // Trailing underscore is okay
 }

--- a/packages/linkifyjs/src/scanner.js
+++ b/packages/linkifyjs/src/scanner.js
@@ -94,6 +94,7 @@ export function init(customSchemes = []) {
 	tt(Start, '~', tk.TILDE);
 	tt(Start, '_', tk.UNDERSCORE);
 	tt(Start, '\\', tk.BACKSLASH);
+	tt(Start, '・', tk.FULLWIDTHMIDDLEDOT);
 
 	const Num = tr(Start, re.DIGIT, tk.NUM, { [fsm.numeric]: true });
 	tr(Num, re.DIGIT, Num);

--- a/packages/linkifyjs/src/text.js
+++ b/packages/linkifyjs/src/text.js
@@ -76,6 +76,7 @@ export const PLUS = 'PLUS'; // +
 export const POUND = 'POUND'; // #
 export const QUERY = 'QUERY'; // ?
 export const QUOTE = 'QUOTE'; // "
+export const FULLWIDTHMIDDLEDOT = 'FULLWIDTHMIDDLEDOT'; // ・
 
 export const SEMI = 'SEMI'; // ;
 export const SLASH = 'SLASH'; // /

--- a/test/spec/linkify-plugin-hashtag.test.js
+++ b/test/spec/linkify-plugin-hashtag.test.js
@@ -80,6 +80,14 @@ describe('linkify-plugin-hashtag', () => {
 			expect(linkify.test('#سلام', 'hashtag')).to.be.ok;
 		});
 
+		it('Works with Japanese characters', () => {
+			expect(linkify.test('#おはよう', 'hashtag')).to.be.ok;
+		});
+
+		it('Works with Japanese characters and full width middle dot', () => {
+			expect(linkify.test('#おは・よう', 'hashtag')).to.be.ok;
+		});
+
 		it('Works with emojis', () => {
 			expect(linkify.test('#🍭', 'hashtag')).to.be.ok;
 		});

--- a/test/spec/linkifyjs/scanner.test.js
+++ b/test/spec/linkifyjs/scanner.test.js
@@ -27,6 +27,7 @@ const tests = [
 	['$', [t.DOLLAR], ['$']],
 	['=', [t.EQUALS], ['=']],
 	['-', [t.HYPHEN], ['-']],
+	['・', [t.FULLWIDTHMIDDLEDOT], ['・']],
 	['&?<>(', [t.AMPERSAND, t.QUERY, t.OPENANGLEBRACKET, t.CLOSEANGLEBRACKET, t.OPENPAREN], ['&', '?', '<', '>', '(']],
 	['([{}])', [t.OPENPAREN, t.OPENBRACKET, t.OPENBRACE, t.CLOSEBRACE, t.CLOSEBRACKET, t.CLOSEPAREN], ['(', '[', '{', '}', ']', ')']],
 	['!,;\'', [t.EXCLAMATION, t.COMMA, t.SEMI, t.APOSTROPHE], ['!', ',', ';', '\'']],
@@ -82,6 +83,11 @@ const tests = [
 		'#АБВ_бв #한글 #سلام',
 		[t.POUND, t.UWORD, t.UNDERSCORE, t.UWORD, t.WS, t.POUND, t.UWORD, t.WS, t.POUND, t.UWORD],
 		['#', 'АБВ', '_', 'бв', ' ', '#', '한글', ' ', '#', 'سلام']
+	],
+	[
+		'#おは・よう',
+		[t.POUND, t.UWORD, t.FULLWIDTHMIDDLEDOT, t.UWORD],
+		['#', 'おは', '・', 'よう']
 	],
 	[
 		'テストexample.comテスト',


### PR DESCRIPTION
Nice to meet you, Thank you for the great OSS you are providing!
I love to using this OSS! 

There is one problem in hashtag plugin with Japanese that I would like to fix, and I am sending this pull request. 

### Issue

- linkifyjs hashtag plugin cannot parse full width middle dot `・` correctly
- Full width middle dot `・` is a very important symbol in Japanese
  - That is used in many cases in Japanese
    - Name of person
    - Title of the work
    - Name of a sports team
    - Name of brand
- X (formerly Twitter) supports full width middle dot in hashtags

### Examples

- `#アラン・チューリング`
  - Alan Mathison Turing
- `#スター・ウォーズ`
  - STAR WARS
- `#レアル・マドリード`
  - Real Madrid CF
- `#コカ・コーラ`
  - coca cola

### How to fix

- I've added `FULLWIDTHMIDDLEDOT` to
  - `packages/linkifyjs/src/text.js`
  - `packages/linkifyjs/src/scanner.js`
- I've updated `packages/linkify-plugin-hashtag/src/hashtag.js`
- I've added test cases to
  - `test/spec/linkifyjs/scanner.test.js`
  - `test/spec/linkify-plugin-hashtag.test.js`

### What I've checked

- [x] npm run build
- [x] npm run lint
- [x] npm run test

-----

I would be very grateful if this issue could be fixed.
I would appreciate your consideration of merge this pull request.

